### PR TITLE
fixed queue.back for single node queue

### DIFF
--- a/data_structures/queue/queue.py
+++ b/data_structures/queue/queue.py
@@ -1,6 +1,7 @@
 from .node import Node
 from typing import Any
 
+
 class Queue(object):
     """
     """
@@ -19,8 +20,8 @@ class Queue(object):
             for i in vals:
                 newNode = Node(i)
                 if self.front is None:  # this is the first node in queue
-                    self.front = newNode
-                elif self.back is None:  # this is the second node in queue
+                    self.front, self.back = newNode, newNode
+                elif self.back is self.front:  # this is the second node
                     self.front._next, self.back = newNode, newNode
                 else:
                     self.back._next, self.back = newNode, newNode
@@ -41,8 +42,8 @@ class Queue(object):
         """
         newNode = Node(val)
         if self.front is None:  # this is the first node in queue
-            self.front = newNode
-        elif self.back is None:  # this is the second node in queue
+            self.front, self.back = newNode, newNode
+        elif self.back is self.front:  # this is the second node
             self.front._next, self.back = newNode, newNode
         else:
             self.back._next, self.back = newNode, newNode

--- a/data_structures/queue/test_queue.py
+++ b/data_structures/queue/test_queue.py
@@ -12,6 +12,7 @@ def test_alive():
 def empty_q():
     return Queue()
 
+
 @pytest.fixture
 def small_q():
     q = Queue([1, 2, 3, 4])
@@ -88,7 +89,7 @@ def test_queue_enque_increases_queue_size(empty_q):
 
 
 def test_enqueue_continues_to_add_multiple_nodes(empty_q):
-    """ Multiple calls to to enqueue method continues to add elements & increment length
+    """ Multiple calls to to enqueue method add elements & increment length
     """
     expected = len(empty_q) + 4
     empty_q.enqueue(42)
@@ -99,7 +100,7 @@ def test_enqueue_continues_to_add_multiple_nodes(empty_q):
 
 
 def test_small_q_is_valid_queue(small_q):
-    """ We are depending on small_q, so let's make sure it is a Queue data structure
+    """ We are depending on small_q, so let's make sure it's a Queue data structure
     """
     assert isinstance(small_q, Queue)
 
@@ -127,7 +128,7 @@ def test_queue_str_format_on_one_element(empty_q):
     """ Do we get the expected str return when queue has 1 Node with a value
     """
     q = Queue(42)
-    expected = 'Front: 42 | Back: None | Length: 1'
+    expected = 'Front: 42 | Back: 42 | Length: 1'
     actual = str(q)
     assert expected == actual
     qq = empty_q
@@ -184,7 +185,7 @@ def test_dequeue_modifies_length(small_q):
         and returns the value that was stored at the front position.
     """
     expected_length = len(small_q) - 1
-    output = small_q.dequeue()
+    small_q.dequeue()
     actual_length = len(small_q)
     assert expected_length == actual_length
 
@@ -228,4 +229,3 @@ def test_node_str_return():
     expected_a = str(input_a)
     actual_a = str(Node(input_a))
     assert expected_a == actual_a
-

--- a/data_structures/stack/test_stack.py
+++ b/data_structures/stack/test_stack.py
@@ -196,4 +196,3 @@ def test_node_str_return():
     expected_a = str(input_a)
     actual_a = str(Node(input_a))
     assert expected_a == actual_a
-


### PR DESCRIPTION
Previously queue.back was not set until the second node was added to the queue. Now it correctly sets both queue.front and queue.back for a single node queue. 

The only linter errors I see are the ones from the typing import. It seems to me that pep8 and flake8 are not accurately setup to work with typing. I could remove the typing, especially since they are not strictly enforced in the code, but I like the reminder of the type even if the linter is flagging it as an error. 